### PR TITLE
add edge cases; fix soul_transfer bugs

### DIFF
--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -176,7 +176,7 @@ impl Contract {
                 &owner,
                 &IssuerTokenId {
                     issuer_id: last.0.issuer_id,
-                    token: last.0.class_id,
+                    token: last.0.class_id,  // we reise IssuerTokenId type here (to not generate new code), but we store class_id instead of token here.
                 },
             );
         }

--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -841,13 +841,10 @@ mod tests {
         ctx.predecessor_account_id = alice();
 
         let limit: u32 = 25; //anything above this limit will fail due to exceeding maximum gas usage per call
-        loop {
+        while result.1 {
             ctx.prepaid_gas = max_gas;
             testing_env!(ctx.clone());
             let result = ctr._sbt_soul_transfer(alice2(), limit as usize);
-            if result.1 == true {
-                break;
-            }
         }
 
         // check all the balances afterwards


### PR DESCRIPTION
- add unit tests to check the events and the edge cases
- update the comments 

Bugs:
- wrong index in the `last` transferred token
- we were using `token_id` in place of `class_id`

The limit for `_soul_transfer` that does not exceeds the max_gas_usage per call is `25`