### PR TITLE
[BUG] sbt_tokens_by_owner

### DIFF
--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -1883,4 +1883,24 @@ mod tests {
         assert!(!ctr.is_human(carol()));
         assert!(ctr.is_human(dan()));
     }
+
+    #[test]
+    fn sbt_tokens_by_owner_per_issuer() {
+        let (mut ctx, mut ctr) = setup(&&issuer1(), 20 * MINT_DEPOSIT);
+        let batch_metadata = mk_batch_metadata(20);
+        ctr.sbt_mint(vec![(alice(), batch_metadata[..10].to_vec())]);
+
+        ctx.predecessor_account_id = issuer2();
+        testing_env!(ctx.clone());
+        ctr.sbt_mint(vec![(alice(), batch_metadata[10..].to_vec())]);
+
+        let res = ctr.sbt_tokens_by_owner(alice(), None, None, None, None);
+        assert_eq!(res[0].1.len(), 10); // here the results are correct
+        assert_eq!(res[1].1.len(), 10);
+
+        let res = ctr.sbt_tokens_by_owner(alice(), Some(issuer1()), None, None, None);
+        assert_eq!(res[0].1.len(), 10); // here the results we are getting from the call are missing the first token (only 9 tokens returnd)
+        let res = ctr.sbt_tokens_by_owner(alice(), Some(issuer2()), None, None, None);
+        assert_eq!(res[0].1.len(), 10);
+    }
 }


### PR DESCRIPTION
The return value is incorrect when we specify the issuer. The first token is missing