### PR TITLE
BUG :revoke event missing

### DIFF
--- a/contracts/registry/src/registry.rs
+++ b/contracts/registry/src/registry.rs
@@ -17,6 +17,7 @@ impl SBTRegistry for Contract {
      * QUERIES
      **********/
 
+    /// returns the token, if it does not exist returns None
     fn sbt(&self, issuer: AccountId, token: TokenId) -> Option<Token> {
         let issuer_id = self.assert_issuer(&issuer);
         self.issuer_tokens
@@ -24,6 +25,7 @@ impl SBTRegistry for Contract {
             .map(|td| td.to_token(token))
     }
 
+    /// returns total amount of tokens minted by the given issuer
     fn sbt_supply(&self, issuer: AccountId) -> u64 {
         let issuer_id = match self.sbt_issuers.get(&issuer) {
             None => return 0,
@@ -155,7 +157,7 @@ impl SBTRegistry for Contract {
         let mut prev_issuer = issuer_id;
 
         let now = env::block_timestamp_ms();
-        let non_expired = !with_expired.unwrap_or(false);
+        let with_expired = with_expired.unwrap_or(false);
 
         for (key, token_id) in
             self.balances
@@ -177,7 +179,7 @@ impl SBTRegistry for Contract {
                 prev_issuer = key.issuer_id;
             }
             let t: TokenData = self.get_token(key.issuer_id, token_id);
-            if non_expired && t.metadata.expires_at().unwrap_or(now) < now {
+            if !with_expired && t.metadata.expires_at().unwrap_or(now) < now {
                 continue;
             }
             tokens.push(OwnedToken {


### PR DESCRIPTION
Added:
+ changed `non_expired` to `with_expired` variable name inside of `sbt_tokens_by_owner` method (easier to read)
+ unit test for `is_human` when only one of the tokens is expired
+ [BUG] unit test that exposes a bug in `sbt_revoke`. I think we are missing the `Revoke` event when burning the tokens (only burn is emitted). According to NEP-393 we should be emitting both events in that case