### PR TITLE
bug fix

### DIFF
--- a/contracts/community-sbt/src/lib.rs
+++ b/contracts/community-sbt/src/lib.rs
@@ -102,9 +102,9 @@ impl Contract {
         let promise = if requires_iah {
             sbt_reg
                 .with_static_gas(MINT_GAS + IS_HUMAN_GAS)
-                .sbt_mint(token_spec)
+                .sbt_mint_iah(token_spec)
         } else {
-            sbt_reg.with_static_gas(MINT_GAS).sbt_mint_iah(token_spec)
+            sbt_reg.with_static_gas(MINT_GAS).sbt_mint(token_spec)
         };
         Ok(promise)
     }


### PR DESCRIPTION
+ the logic was reversed. When `requires_iah = false` we call `sbt_mint_iah` and when `requires_iah = true` we call `sbt_mint`