### PR TITLE
feat: registry.sbt_classes

### DIFF
--- a/contracts/registry/src/lib.rs
+++ b/contracts/registry/src/lib.rs
@@ -934,11 +934,19 @@ mod tests {
 
         let sbts = ctr.sbts(issuer1(), vec![1, 2]);
         assert_eq!(sbts, vec![Some(sbt1_1_e.clone()), Some(sbt1_2_e.clone())]);
+        assert_eq!(
+            ctr.sbt_classes(issuer1(), vec![1, 1]),
+            vec![Some(1), Some(1)]
+        );
 
         let sbts = ctr.sbts(issuer1(), vec![2, 10, 3, 1]);
         assert_eq!(
             sbts,
             vec![Some(sbt1_2_e.clone()), None, None, Some(sbt1_1_e.clone())]
+        );
+        assert_eq!(
+            ctr.sbt_classes(issuer1(), vec![2, 10, 3, 1]),
+            vec![Some(1), None, None, Some(1)]
         );
 
         assert_eq!(1, ctr.sbt_supply_by_owner(alice(), issuer1(), None));

--- a/contracts/registry/src/registry.rs
+++ b/contracts/registry/src/registry.rs
@@ -20,8 +20,8 @@ impl SBTRegistry for Contract {
             .map(|td| td.to_token(token))
     }
 
-    /// Get the information about list of token IDs issued by the `issuer` SBT contract.
-    /// If token ID is not found `None` is set in the specific return index.
+    /// Get the information about list of token IDs issued by the SBT `issuer`.
+    /// If token ID is not found, `None` is set in the specific return index.
     fn sbts(&self, issuer: AccountId, tokens: Vec<TokenId>) -> Vec<Option<Token>> {
         let issuer_id = self.assert_issuer(&issuer);
         tokens
@@ -30,6 +30,20 @@ impl SBTRegistry for Contract {
                 self.issuer_tokens
                     .get(&IssuerTokenId { issuer_id, token })
                     .map(|td| td.to_token(token))
+            })
+            .collect()
+    }
+
+    /// Query class ID for each token ID issued by the SBT `issuer`.
+    /// If token ID is not found, `None` is set in the specific return index.
+    fn sbt_classes(&self, issuer: AccountId, tokens: Vec<TokenId>) -> Vec<Option<ClassId>> {
+        let issuer_id = self.assert_issuer(&issuer);
+        tokens
+            .into_iter()
+            .map(|token| {
+                self.issuer_tokens
+                    .get(&IssuerTokenId { issuer_id, token })
+                    .map(|td| td.metadata.class_id())
             })
             .collect()
     }

--- a/contracts/sbt/src/lib.rs
+++ b/contracts/sbt/src/lib.rs
@@ -58,9 +58,13 @@ pub trait SBTRegistry {
     /// Get the information about specific token ID issued by the `issuer` SBT contract.
     fn sbt(&self, issuer: AccountId, token: TokenId) -> Option<Token>;
 
-    /// Get the information about list of token IDs issued by the `issuer` SBT contract.
-    /// If token ID is not found `None` is set in the specific return index.
+    /// Get the information about list of token IDs issued by the SBT `issuer`.
+    /// If token ID is not found, `None` is set in the specific return index.
     fn sbts(&self, issuer: AccountId, token: Vec<TokenId>) -> Vec<Option<Token>>;
+
+    /// Query class ID for each token ID issued by the SBT `issuer`.
+    /// If token ID is not found, `None` is set in the specific return index.
+    fn sbt_classes(&self, issuer: AccountId, tokens: Vec<TokenId>) -> Vec<Option<ClassId>>;
 
     /// Returns total amount of tokens issued by `issuer` SBT contract, including expired
     /// tokens. Depending on the implementation, if a revoke removes a token, then it should


### PR DESCRIPTION
Added new `sbt_classes` method to the Registry interface.
It helps to query class IDs based on token IDs.